### PR TITLE
Implementacion de text chunker

### DIFF
--- a/services/Chroma_service.py
+++ b/services/Chroma_service.py
@@ -1,5 +1,6 @@
 from chromadb import PersistentClient
 from uuid import uuid4
+from utils.Text_chunker import split_into_chunks
 
 class ChromaService:
 
@@ -10,12 +11,14 @@ class ChromaService:
 
     # Procesa y guarda documentos en ChromaDB
     def add_document(self, filename: str, content: str):
-        doc_id = str(uuid4())  # Genera un ID único para el documento
-        self.collection.add(
-            documents=[content],
-            metadatas=[{"nombre": filename}],
-            ids=[doc_id]
-        )
+        chucks = split_into_chunks(content) # Divide el contenido en fragmentos (chunks)
+        for chuck in chucks:
+            doc_id = str(uuid4())  # Genera un ID único para el documento
+            self.collection.add(
+                documents=[chuck],
+                metadatas=[{"nombre": filename}],
+                ids=[doc_id]
+            )
 
     # Muestra todos los documentos en ChromaDB
     def get_all_documents(self):

--- a/utils/Text_chunker.py
+++ b/utils/Text_chunker.py
@@ -1,0 +1,11 @@
+# Text Chunker
+# parametro chunk_size: tamaño del chuck
+# parametro overlap: sobrelaparción entre chucks para evitar perdida de contexto
+def split_into_chunks(text: str, chunk_size: int = 500, overlap: int = 50) -> list[str]:
+    chunks = []
+    start = 0
+    while start < len(text):
+        end = min(start + chunk_size, len(text))
+        chunks.append(text[start:end])
+        start += chunk_size - overlap
+    return chunks


### PR DESCRIPTION
Se implementó un text chunker para dividir grandes bloques de texto en fragmentos más pequeños y manejables para la inteligencia artificial. Con el máximo de 500 de palabras y 50 palabras de solapamiento